### PR TITLE
change SpannableString to html to fix NotSerializableException

### DIFF
--- a/app/src/main/java/awais/instagrabber/adapters/MessageItemsAdapter.java
+++ b/app/src/main/java/awais/instagrabber/adapters/MessageItemsAdapter.java
@@ -159,6 +159,9 @@ public final class MessageItemsAdapter extends RecyclerView.Adapter<TextMessageV
             DirectItemMediaModel mediaModel = directItemModel.getMediaModel();
             switch (itemType) {
                 case PLACEHOLDER:
+                    holder.tvMessage.setText(HtmlCompat.fromHtml(directItemModel.getText().toString(), 63));
+                    holder.tvMessage.setVisibility(View.VISIBLE);
+                    break;
                 case TEXT:
                     text = directItemModel.getText();
                     text = Utils.getSpannableUrl(text.toString()); // for urls

--- a/app/src/main/java/awais/instagrabber/utils/Utils.java
+++ b/app/src/main/java/awais/instagrabber/utils/Utils.java
@@ -655,14 +655,10 @@ public final class Utils {
 
                 case PLACEHOLDER: {
                     final JSONObject placeholder = itemObject.getJSONObject("placeholder");
-
                     final String title = placeholder.getString("title");
                     final String message = placeholder.getString("message");
-
-                    final SpannableString spannableString = new SpannableString(title + '\n' + message);
-                    spannableString.setSpan(new RelativeSizeSpan(1.15f), 0, title.length(), 0);
-
-                    text = hasMentions(message) ? getMentionText(spannableString) : spannableString;
+                    final String string = title + "<br><small>" + message + "</small>";
+                    text = hasMentions(message) ? getMentionText(string) : string;
                 }
                 break;
 


### PR DESCRIPTION
I had a direct message which had a 'placeholder' item type for the DirectItemModel.
When starting the DirectMessagesUserInbox activity, the InboxThreadModel is passed as the tag during which it is serialized. But the serialization failed due to the non-serialzable property 'text', which is of the type SpannableString. This happens since SpannableString is not serializable.

I have fixed this error, by converting the SpannableString to an html string and parsing the html in MessageItemsAdapter.

The stackstrace is as follows:

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: me.austinhuang.instagrabber, PID: 24443
    java.lang.RuntimeException: Parcelable encountered IOException writing serializable object (name = awais.instagrabber.models.direct_messages.InboxThreadModel)
        at android.os.Parcel.writeSerializable(Parcel.java:1833)
        at android.os.Parcel.writeValue(Parcel.java:1780)
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928)
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1589)
        at android.os.Bundle.writeToParcel(Bundle.java:1253)
        at android.os.Parcel.writeBundle(Parcel.java:997)
        at android.content.Intent.writeToParcel(Intent.java:10524)
        at android.app.IActivityTaskManager$Stub$Proxy.startActivity(IActivityTaskManager.java:3863)
        at android.app.Instrumentation.execStartActivity(Instrumentation.java:1891)
        at android.app.Activity.startActivityForResult(Activity.java:5210)
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:676)
        at android.app.Activity.startActivityForResult(Activity.java:5168)
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:663)
        at android.app.Activity.startActivity(Activity.java:5539)
        at android.app.Activity.startActivity(Activity.java:5507)
        at awais.instagrabber.activities.DirectMessages.lambda$new$0$DirectMessages(DirectMessages.java:32)
        at awais.instagrabber.activities.-$$Lambda$DirectMessages$mfi3RGFwXBUX0xqMGdJ6oqyzTCA.onClick(Unknown Source:2)
        at android.view.View.performClick(View.java:7201)
        at android.view.View.performClickInternal(View.java:7170)
        at android.view.View.access$3500(View.java:806)
        at android.view.View$PerformClick.run(View.java:27582)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7710)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
     Caused by: java.io.NotSerializableException: android.text.SpannableString
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1240)
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1604)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1565)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1488)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1234)
        at java.io.ObjectOutputStream.writeArray(ObjectOutputStream.java:1434)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1230)
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1604)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1565)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1488)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1234)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:354)
        at android.os.Parcel.writeSerializable(Parcel.java:1828)
        at android.os.Parcel.writeValue(Parcel.java:1780) 
        at android.os.Parcel.writeArrayMapInternal(Parcel.java:928) 
        at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1589) 
        at android.os.Bundle.writeToParcel(Bundle.java:1253) 
        at android.os.Parcel.writeBundle(Parcel.java:997) 
        at android.content.Intent.writeToParcel(Intent.java:10524) 
        at android.app.IActivityTaskManager$Stub$Proxy.startActivity(IActivityTaskManager.java:3863) 
        at android.app.Instrumentation.execStartActivity(Instrumentation.java:1891) 
        at android.app.Activity.startActivityForResult(Activity.java:5210) 
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:676) 
        at android.app.Activity.startActivityForResult(Activity.java:5168) 
        at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:663) 
        at android.app.Activity.startActivity(Activity.java:5539) 
        at android.app.Activity.startActivity(Activity.java:5507) 
        at awais.instagrabber.activities.DirectMessages.lambda$new$0$DirectMessages(DirectMessages.java:32) 
        at awais.instagrabber.activities.-$$Lambda$DirectMessages$mfi3RGFwXBUX0xqMGdJ6oqyzTCA.onClick(Unknown Source:2) 
        at android.view.View.performClick(View.java:7201) 
        at android.view.View.performClickInternal(View.java:7170) 
        at android.view.View.access$3500(View.java:806) 
        at android.view.View$PerformClick.run(View.java:27582) 
        at android.os.Handler.handleCallback(Handler.java:883) 
        at android.os.Handler.dispatchMessage(Handler.java:100) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7710)
```